### PR TITLE
Use locale subdomain for SurveyMonkey privacy and terms of use links

### DIFF
--- a/app/helpers/pano/link_helper.rb
+++ b/app/helpers/pano/link_helper.rb
@@ -4,15 +4,15 @@ module Pano
     # shortcuts for hardcoded absolute URLs
 
     def privacy_url
-      'https://www.surveymonkey.com/mp/policy/privacy-policy/#respondents'
+      "https://#{I18n.locale}.surveymonkey.com/mp/policy/privacy-policy/#respondents"
     end
 
     def terms_of_use_url
-      'https://www.surveymonkey.com/mp/policy/terms-of-use/'
+      "https://#{I18n.locale}.surveymonkey.com/mp/policy/terms-of-use/"
     end
 
     def trial_terms_of_use_url
-      'https://www.surveymonkey.com/mp/policy/surveymonkey-trial-account-terms-service/'
+      "https://#{I18n.locale}.surveymonkey.com/mp/policy/surveymonkey-trial-account-terms-service/"
     end
 
     def mark_if_current(options)


### PR DESCRIPTION
@jmckible Instincts on validation? Could make a list of known good locales, or is that overkill?

I was going to go with something like:
```
      subdomain = I18n.locale.present? ? I18n.locale : 'www'
```
but after testing locally, it appears Engage is transparently defaulted to `:en`
