### PR TITLE
Modal Fixes

### DIFF
--- a/app/assets/javascripts/pano/app/modals.coffee
+++ b/app/assets/javascripts/pano/app/modals.coffee
@@ -15,12 +15,34 @@ UI.click '.js-modal', (e, el) ->
   e.preventDefault()
   href = el.attr('href')
   $('body').css('overflow', 'hidden')
+
+  #// snapPixels allows us to fix the fuzzy text caused by 3d transformations on Safari and Chrome
+  #// this can be removed when and if these browser bugs are fixed
+  snapPixels = (el) ->
+    modal = $(el).find('.modal-wrapper')
+    top = modal.position().top
+    newY = Math.round(top)
+    left = modal.position().left
+    newX = Math.round(left)
+
+    if left != newX && top != newY
+      leftCorrection = left - parseInt(left)
+      topCorrection = top - parseInt(top)
+      modal.css('transform', 'translate3d(calc(-50% - ' + leftCorrection + 'px), calc(-50% - ' + topCorrection + 'px), 0)')
+    else if left != newX
+      leftCorrection = left - parseInt(left)
+      modal.css('transform', 'translate3d(calc(-50% - ' + leftCorrection + 'px), 50%, 0)')
+    else if top != newY
+      topCorrection = top - parseInt(top)
+      modal.css('transform', 'translate3d(-50%, calc(-50% - ' + topCorrection + 'px), 0)')
+
   if href.indexOf('#') == 0
     data = $(el).data()
 
-    Modals.show $(href), data
+    Modals.show $(href), data, [snapPixels]
   else
-    Modals.showAjax(href, null, [$.bindFormValidation])
+    Modals.showAjax(href, null, [$.bindFormValidation, snapPixels])
+
 
 UI.click '.js-close-modal', (e, el) ->
   $target = $(e.target)
@@ -40,6 +62,11 @@ window.Modals =
       setModalTop(modal)
       modal.fadeIn 200
       Modals.currentModals.push modal
+
+      if callbacks
+        for callback in callbacks
+          do ->
+            callback(modal)
 
   close: (modal) ->
     if modal

--- a/app/assets/stylesheets/pano/global/_modals.sass
+++ b/app/assets/stylesheets/pano/global/_modals.sass
@@ -12,6 +12,7 @@ $z: 1000
     position: fixed
     left: 50%
     top: 50%
+    transform: translate3d(-50%, -50%, 0)
     z-index: $z+2
     +mobile
       left: 0
@@ -39,7 +40,6 @@ $z: 1000
   position: relative
   max-width: 560px
   max-height: 90%
-  margin: -50% 0 0 -50%
   overflow: auto
   padding: 24px
   font-family: $font-stack
@@ -123,7 +123,7 @@ $z: 1000
   &.calendar
     max-width: 600px
   &.color-picker-modal
-    min-height: 340px
+    display: inline-table
   +mobile
     max-width: 100%
     min-height: 100%

--- a/lib/pano/version.rb
+++ b/lib/pano/version.rb
@@ -1,3 +1,3 @@
 module Pano
-  VERSION = '2.1.1'
+  VERSION = '2.1.2'
 end


### PR DESCRIPTION
Fix to allow color picker to overflow modals so they don't scroll
fix for fuzzy text and positioning of modals 

This solution uses JavaScript, as the usual CSS hacks to work around the browser bugs cannot work reliably. This is because we are working with so many modals of different sizes. The solution is to use JavaScript to fix the position after the effects have occurred so that we can fix the modal on a pixel. Subpixel positioning causes blurry text in Chrome and Safari (on OS X at least)

cx/#2704, cx/#2720