### PR TITLE
Centering Modals Change

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    pano (2.0.0)
+    pano (2.1.6)
       bourbon (= 4.3.4)
       coffee-rails (= 4.2.1)
       haml (= 5.0.1)
@@ -137,7 +137,7 @@ GEM
       rspec-mocks (~> 3.5.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
-    sass (3.5.1)
+    sass (3.5.2)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -151,7 +151,7 @@ GEM
     sprockets (3.7.1)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
-    sprockets-rails (3.2.0)
+    sprockets-rails (3.2.1)
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
@@ -178,4 +178,4 @@ DEPENDENCIES
   sqlite3
 
 BUNDLED WITH
-   1.15.3
+   1.15.4

--- a/app/assets/javascripts/pano/app/modals.coffee
+++ b/app/assets/javascripts/pano/app/modals.coffee
@@ -7,7 +7,7 @@
 
 UI.click('.modal-bg', (e, el) ->
   $target = $(e.target)
-  modal = $target.closest('.modal-container')
+  modal = $target.closest('.modal')
   Modals.close(modal)
 )
 
@@ -25,7 +25,7 @@ UI.click '.js-modal', (e, el) ->
 
 UI.click '.js-close-modal', (e, el) ->
   $target = $(e.target)
-  modal = $target.closest('.modal-container')
+  modal = $target.closest('.modal')
   Modals.close(modal)
 
 
@@ -43,7 +43,7 @@ window.Modals =
       modal.fadeIn duration: 200,
       progress: ->
         centerModal(modal)
-      ,done: ->
+      done: ->
         addModalResizeListener(modal)
 
       Modals.currentModals.push modal

--- a/app/assets/javascripts/pano/app/modals.coffee
+++ b/app/assets/javascripts/pano/app/modals.coffee
@@ -40,12 +40,7 @@ window.Modals =
     if modal
       $('body').css('overflow', 'hidden')
       # // need to center during the fadeIn animation
-      modal.fadeIn duration: 200,
-      progress: ->
-        centerModal(modal)
-      done: ->
-        addModalResizeListener(modal)
-
+      modal.fadeIn duration: 200
       Modals.currentModals.push modal
 
       if callbacks
@@ -86,8 +81,6 @@ window.Modals =
           callbacks.forEach((callback) -> if _.isFunction(callback) then callback(htmlResponse))
 
         $('body').css('overflow', 'hidden')
-        centerModal(modal)
-        addModalResizeListener(modal)
 
     ).fail((jqXHR, textStatus, errorThrown) ->
 
@@ -105,26 +98,6 @@ window.Modals =
         <h2>Loading...</h2>
       </div>
     """
-
-# =====================================================
-#  Modal Helpers
-# =====================================================
-#//  poisitions modal vertical and hortizontal center, since CSS positioning causes blurry text in some cases on OS X Chrome and Safari
-centerModal = (el) ->
-  modal = $(el).find('.modal-wrapper')
-  top = ($(window).height() - modal.height()) / 2
-  left = ($(window).width() - modal.width()) / 2
-
-  modal.css('top', top).css('left', left)
-
-addModalResizeListener = (el) ->
-  $(window).resize ->
-    centerModal(el)
-
-setModalTop = (modal) ->
-  #modal.css('top', "#{$(window).scrollTop() + ($(window).height() / 10)}px")
-
-
 
 ##Override the default confirm dialog by rails
 #$.rails.allowAction = (link) ->

--- a/app/assets/stylesheets/pano/global/_modals.sass
+++ b/app/assets/stylesheets/pano/global/_modals.sass
@@ -25,11 +25,7 @@ $z: 1000
     vertical-align: middle
     text-align: center
     +mobile
-    
-    .modal-body
-      z-index: $z+2
-      display: inline-block
-    
+     
   .modal-bg
     position: fixed
     z-index: $z+1

--- a/app/assets/stylesheets/pano/global/_modals.sass
+++ b/app/assets/stylesheets/pano/global/_modals.sass
@@ -4,22 +4,32 @@
 
 $z: 1000
 
-.modal-container
+.modal
   display: none
   position: fixed
   z-index: $z
-  .modal-wrapper
-    position: fixed
+  top: 0 
+  left: 0
+  bottom: 0
+  right: 0
+  text-align: center
+  &:before
+    content: ''
+    display: inline-block
+    height: 100%
+    vertical-align: middle
+  .modal-dialog
+    position: relative
     z-index: $z+2
+    display: inline-block
+    vertical-align: middle
+    text-align: center
     +mobile
-      left: 0
-      right: 0
-      top: 0
-      bottom: 0
-
-    .modal
+    
+    .modal-body
       z-index: $z+2
-
+      display: inline-block
+    
   .modal-bg
     position: fixed
     z-index: $z+1
@@ -28,16 +38,14 @@ $z: 1000
     right: 0
     bottom: 0
     text-align: center
-    // background: #fff
-    // opacity: 0.6
     background: #03182b //$dark-blue
     opacity: 0.5
 
 =modal
   position: relative
+  display: table-cell
   max-width: 560px
   max-height: 90%
-  margin: 0
   overflow: auto
   padding: 24px
   font-family: $font-stack
@@ -57,9 +65,8 @@ $z: 1000
     max-height: 100%
     margin: 0
 
-.modal
+.modal-content
   +modal
-
   &.wide-modal
     max-width: 640px
   .close-icon
@@ -94,6 +101,7 @@ $z: 1000
   //   margin-top: 12px
 
 .modal-body
+  width: 100%
   position: relative // helps contain absolutely-positioned elements inside
   padding: 24px 0
 

--- a/app/assets/stylesheets/pano/global/_modals.sass
+++ b/app/assets/stylesheets/pano/global/_modals.sass
@@ -39,7 +39,6 @@ $z: 1000
 
 =modal
   position: relative
-  display: table-cell
   max-width: 560px
   max-height: 90%
   overflow: auto

--- a/app/helpers/pano/modal_helper.rb
+++ b/app/helpers/pano/modal_helper.rb
@@ -2,14 +2,14 @@ module Pano
   module ModalHelper
 
     def modal(id, title, options = {}, &block)
-      options[:class] = [options[:class], 'modal box'].join(' ')
+      options[:class] = [options[:class], 'modal-content'].join(' ')
       icon = options[:icon]
       description = options[:description]
       # If assigns is undefined we're outside of rails controller (e.g. in asset pipeline or pdf rendering context)
       # s_capture won't work in that case, so fall back to capture
       inner_content = capture(&block)
-      div_tag class: 'modal-container', id: id do
-        modal = div_tag class: 'modal-wrapper' do
+      div_tag class: 'modal', id: id do
+        modal = div_tag class: 'modal-dialog' do
           div_tag options do
             close_modal_icon + modal_header(title, icon, description) + inner_content
           end

--- a/app/helpers/pano/modal_helper.rb
+++ b/app/helpers/pano/modal_helper.rb
@@ -1,17 +1,24 @@
 module Pano
   module ModalHelper
 
-    def modal(id, title, options = {}, &block)
+    def modal(id, title = nil, options = {}, &block)
       options[:class] = [options[:class], 'modal-content'].join(' ')
       icon = options[:icon]
       description = options[:description]
       # If assigns is undefined we're outside of rails controller (e.g. in asset pipeline or pdf rendering context)
       # s_capture won't work in that case, so fall back to capture
       inner_content = capture(&block)
+
+      if title.any?
+        header = modal_header(title, icon, description)
+      else
+        header = ''
+      end
+
       div_tag class: 'modal', id: id do
         modal = div_tag class: 'modal-dialog' do
           div_tag options do
-            close_modal_icon + modal_header(title, icon, description) + inner_content
+            close_modal_icon + header + inner_content
           end
         end
         modal_bg = div_tag class: 'modal-bg' do

--- a/app/helpers/pano/modal_helper.rb
+++ b/app/helpers/pano/modal_helper.rb
@@ -9,10 +9,10 @@ module Pano
       # s_capture won't work in that case, so fall back to capture
       inner_content = capture(&block)
 
-      if title.any?
-        header = modal_header(title, icon, description)
-      else
+      if title.nil?
         header = ''
+      else
+        header = modal_header(title, icon, description)
       end
 
       div_tag class: 'modal', id: id do


### PR DESCRIPTION
**This PR contains breaking changes**

This PR provides a css based solution for vertically and horizontally centering modals, in addition to more semantic naming for modals.

I felt names like `.modal-container` and `.modal-wrapper` were becoming too ambiguous. I suggest the following changes:

- `.modal-container` changes to `.modal`
- `.modal-wrapper` changes to `.modal-dialog`
- `.modal` changes to `.modal-content`

Example markup for a new modal would be:
```haml
.modal#example-modal
  .modal-dialog
    .modal-content
      .modal-header
        Foo
      .modal-body
        Bar
      .modal-footer
        =btn_to 'OK, '#'
  .modal-bg
```

Given these are breaking changes, this may need to be merged into a release branch separate from stable to be coordinated for a release later. @jmckible @tjdo, let me know your thoughts on how much work this would be to implement in CX if we chose to adopt it. 


## Pano Review Process Thoughts

I'd like to use this PR as an example for future Pano PRs, in that we should be asking anyone who might be affected by the changes for a review, so it gives each team a chance to test/consider the changes and align them with their work stream. Please feel free to comment on this proposal / add thoughts you have on the process.