### PR TITLE
Proposal: Back button behavior

### DIFF
--- a/app/helpers/pano/button_helper.rb
+++ b/app/helpers/pano/button_helper.rb
@@ -54,7 +54,14 @@ module Pano
     # back button
     # ------------------------------------------------------------
 
+    # Use Rails special :back token when a referrer is available
+    # AND it will not send you to the same page
+    # If that default logic still doesn't work, accepts an override :force option
+
     def back_btn_to(label, options = {}, html_options = {})
+      unless html_options[:force]
+        options = :back if request.referer.present? && url_for(options) != request.referer
+      end
       icon_btn_to(:back, label, options, html_options.add_class('btn-white btn-back'))
     end
 


### PR DESCRIPTION
This proposal is targeted at Back buttons like this one:

<img width="394" alt="screen shot 2018-02-28 at 9 39 47 am" src="https://user-images.githubusercontent.com/3744/36803029-57d2184c-1c6b-11e8-83b4-355a50690d85.png">

In the case we are navigating back to a paginated index page, the current method signature is not ideal. Rails has a built in `:back` option which can be used by `link_to` when the referrer is available. For the majority of navigation, this would allow us to easily link back to a deep pagination, rather than the first page of results.

The proposal here is to imply this behavior with our Back button element. However, we must enforce some defensive programming. In the case that no referrer is present, Rails will just output a javascript redirect to the previous page in the browser history - potentially off our site entirely. As such, the current url option will function as a fallback in the case a referrer is not available.

The other edge case is exemplified by the open/close behavior of Feedback in Engage. When updating or commenting on a feedback, we redirect back to the same show page. In this case, the Rails `:back` behavior would link right back to the page. Not good! To work around this, we'll check that the referrer is not the same as the current url. If is it, use the fallback url.

Finally, in the case where we want to bypass the implied behavior entirely, allow for a `force: true` option to override. 