### PR TITLE
Use `\A` and `\z` as anchors in email validator regex to match with w…

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    pano (3.0.1)
+    pano (3.0.2)
       bourbon (= 4.3.4)
       coffee-rails (= 4.2.1)
       haml (= 5.0.1)
@@ -67,7 +67,7 @@ GEM
     diff-lcs (1.3)
     erubi (1.7.0)
     execjs (2.7.0)
-    ffi (1.9.22)
+    ffi (1.9.23)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
     haml (5.0.1)
@@ -88,7 +88,7 @@ GEM
     mini_mime (1.0.0)
     mini_portile2 (2.3.0)
     minitest (5.11.1)
-    nio4r (2.2.0)
+    nio4r (2.3.0)
     nokogiri (1.8.1)
       mini_portile2 (~> 2.3.0)
     rack (2.0.3)
@@ -118,7 +118,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rake (12.3.0)
-    rb-fsevent (0.10.2)
+    rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
     rspec-core (3.7.1)

--- a/app/models/pano/email_validator.rb
+++ b/app/models/pano/email_validator.rb
@@ -1,6 +1,6 @@
 module Pano
   class EmailValidator < ActiveModel::EachValidator
-    EMAIL_REGEX = /^[a-z0-9][a-z0-9._%+-]*(?<!\.)@(?:[-a-z0-9]+\.)+[a-z]{2,}$/i
+    EMAIL_REGEX = /\A[a-z0-9][a-z0-9._%+-]*(?<!\.)@(?:[-a-z0-9]+\.)+[a-z]{2,}\z/i
 
     def validate_each(object,attribute,value)
       if value.blank?

--- a/lib/pano/version.rb
+++ b/lib/pano/version.rb
@@ -1,3 +1,3 @@
 module Pano
-  VERSION = '3.0.1'
+  VERSION = '3.0.2'
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -17,4 +17,13 @@ RSpec.describe User do
     expect(user).to be_valid
   end
 
+  it 'prevents emails with newline characters' do
+    user = User.new email: "name1@gmail.com; \nname2@hotmail.com"
+    expect(user).not_to be_valid
+  end
+
+  it 'prevents emails with semicolons' do
+    user = User.new email: "name1@gmail.com; name2@hotmail.com"
+    expect(user).not_to be_valid
+  end
 end


### PR DESCRIPTION
…hole string (catches new line characters; also: prevent malicious input from being saved before or after a new line character). Addresses techvalidate/cx/issues/3212.