### PR TITLE
[Fix] Make Search icon clickable

### DIFF
--- a/app/assets/stylesheets/pano/global/_forms.sass
+++ b/app/assets/stylesheets/pano/global/_forms.sass
@@ -67,27 +67,12 @@ date-input
 // search fields
 // ------------------------------------------
 
-// search icons inside search fields. the container is because we can't
+// search icon is :after the form button because we can't
 // use :before or :after on an input element
 .search-field-container
+
   position: relative
   width: 250px
-  &:after
-    display: flex
-    justify-content: center
-    content: '\e8b6'
-    position: absolute
-    right: 0
-    top: 0
-    margin: auto
-    font-size: 16px
-    height: 30px
-    width: 30px
-    line-height: 30px
-    pointer-events: none
-    font-family: 'Material Icons'
-    color: $stone
-    border-radius: 2px
 
   input[type="search"]
     display: block
@@ -102,9 +87,36 @@ date-input
       color: $charcoal
       border-bottom: 1px solid $pebble
 
-  &:hover
+  button[type="submit"]
+    margin: 0
+    padding: 0
+    width: 0
+    height: 0
+    border: 0
+    position: absolute
+    bottom: 0
+    right: 0
+
     &:after
-      background: $pebble
+      display: flex
+      justify-content: center
+      content: '\e8b6'
+      position: absolute
+      bottom: 0
+      right: 0
+      margin: auto
+      font-size: 16px
+      height: 30px
+      width: 30px
+      line-height: 30px
+      font-family: 'Material Icons'
+      color: $stone
+      border-radius: 2px
+
+  &:hover
+    button[type="submit"]
+      &:after
+        background: $pebble
 
 
 

--- a/app/models/pano/app_form_builder.rb
+++ b/app/models/pano/app_form_builder.rb
@@ -1,5 +1,5 @@
 module Pano
-  class AppFormBuilder < DateFormBuilder
+  class AppFormBuilder < PanoFormBuilder
     include ActionView::Helpers::FormTagHelper, Pano::ContentHelper, Pano::IconHelper
 
     delegate :content_tag, :capture, to: :@template

--- a/app/models/pano/pano_form_builder.rb
+++ b/app/models/pano/pano_form_builder.rb
@@ -1,5 +1,5 @@
 module Pano
-  class DateFormBuilder < ActionView::Helpers::FormBuilder
+  class PanoFormBuilder < ActionView::Helpers::FormBuilder
     def formatted_date_field(name, options = {})
       hidden_field = @template.hidden_field(@object_name, name, data: {target: 'hidden'})
       date = @template.tag('date-input', {name: "#{@object_name}[#{name}]", role: "textbox", value: @object.read_attribute(name) || @object.send(name), id: sanitize_to_id("#{@object_name}[#{name}]"), tabindex: 0, active: false}.update(options.stringify_keys))
@@ -8,6 +8,10 @@ module Pano
 
     def sanitize_to_id(name)
       name.to_s.delete("]").tr("^-a-zA-Z0-9:.", "_")
+    end
+
+    def search_field(method, options = {})
+      super + @template.button_tag('')
     end
   end
 end

--- a/app/views/pano/components/_date_picker.haml
+++ b/app/views/pano/components/_date_picker.haml
@@ -1,5 +1,5 @@
 .date-picker{data: {controller: 'datepicker'}}
-  = form_with form_args.merge({builder: Pano::DateFormBuilder}) do |f|
+  = form_with form_args.merge({builder: Pano::PanoFormBuilder}) do |f|
     .date-picker-header.grid.m-stack
       .col-6
         %h2 Select Time Frame


### PR DESCRIPTION
Fix for https://jira.surveymonkey.com/browse/SOLN-1658
- Remove the previous, unclickable :after pseudoelement Search icon
- Rename DateFormBuilder to PanoFormBuilder
- Add search_field method to PanoFormBuilder, overriding the default search_field method. 
  - The new search_field method calls the original search_field, and adds on a new submit button.
- Add the previously used :after pseudoelement to the new button to show the Search icon

Note: We use position: absolute, bottom: 0 on submit button and button:after, in order to work around the margin-top: 4 of the search input box.