### PR TITLE
Add table-section-header class using flex

### DIFF
--- a/app/assets/stylesheets/pano/global/_sections.sass
+++ b/app/assets/stylesheets/pano/global/_sections.sass
@@ -18,7 +18,7 @@
 
       h5
         margin: 0
-    .section-header + div, .section-header + p
+    .section-header + div, .section-header + p, .table-section-header + div
       margin-top: 0
     > div
       margin-top: 32px

--- a/app/assets/stylesheets/pano/global/_tables.sass
+++ b/app/assets/stylesheets/pano/global/_tables.sass
@@ -79,3 +79,18 @@ table.plain
 table.p-0
   th, td
     padding: 0
+
+//-----------------------------------
+// tables section headers
+//-----------------------------------
+.table-section-header
+  position: relative
+  margin-bottom: 16px
+  display: flex
+  flex-direction: row
+  justify-content: space-between
+
+  p
+    display: flex
+    flex-direction: column
+    justify-content: center


### PR DESCRIPTION
-Adding the table-section-header class, which can be used to place the "Showing 1 - 25 of 512 employees" text on the left and the search input on the right.

The table-section-header class can be used to replace the float styling previously used.
Dependents: https://github.com/techvalidate/engage/pull/1977

Before:
<img width="1680" alt="your_team_table_section_header_before" src="https://user-images.githubusercontent.com/8647584/47122036-f4f52a00-d229-11e8-8ef4-57b1ef7c1961.png">

After (Note: left text is vertically centered):
<img width="1680" alt="your_team_table_section_header_after" src="https://user-images.githubusercontent.com/8647584/47122035-f4f52a00-d229-11e8-854d-4d3821694b1f.png">