### PR TITLE
Removing input x icon for IE11 from search-field-container class

### DIFF
--- a/app/assets/stylesheets/pano/global/_forms.sass
+++ b/app/assets/stylesheets/pano/global/_forms.sass
@@ -85,6 +85,9 @@ date-input
       color: $charcoal
       border-bottom: 1px solid $pebble
 
+  input[type="search"]::-ms-clear
+    display: none
+
   button[type="submit"]
     position: absolute
     bottom: 0


### PR DESCRIPTION
Dependents: https://github.com/techvalidate/engage/pull/1979

Removing input x icon for IE11 from search-field-container class.
Caused by switching from .search-form to .search-field-container