### PR TITLE
Move search input styling to Pano from Engage

### DIFF
--- a/app/assets/stylesheets/pano/global/_forms.sass
+++ b/app/assets/stylesheets/pano/global/_forms.sass
@@ -81,10 +81,13 @@ date-input
     background: transparent
     border: 0
     border-radius: 0
+    // prevent search input from hiding behind search icon
+    padding-right: 34px
     &.selected, &:focus, &:active
       color: $charcoal
       border-bottom: 1px solid $pebble
 
+  // Hide x clear button for IE11
   input[type="search"]::-ms-clear
     display: none
 


### PR DESCRIPTION
- Moving padding specification from Engage to Pano. Style prevents search filter text from hiding behind the search icon.
- Fixes https://github.com/techvalidate/engage/commit/236e48cd4765fd2cd3fce31ad573c44205fe3ff6

<img width="299" alt="screen shot 2018-10-23 at 4 56 19 pm" src="https://user-images.githubusercontent.com/8647584/47397638-1e5bfd00-d6e5-11e8-9517-6f79f7eeac24.png">


