### PR TITLE
Add _flexbox.sass to replace ul.inline and handle IE overflow wrapping

### DIFF
--- a/app/assets/stylesheets/pano/global/_flexbox.sass
+++ b/app/assets/stylesheets/pano/global/_flexbox.sass
@@ -1,4 +1,4 @@
-ul.flex-row
+.flex-row
   display: flex !important
   flex-direction: row
 

--- a/app/assets/stylesheets/pano/global/_flexbox.sass
+++ b/app/assets/stylesheets/pano/global/_flexbox.sass
@@ -1,0 +1,16 @@
+ul.flex-row
+  display: flex !important
+  flex-direction: row
+
+  .vertically-centered-column
+    display: flex
+    flex-flow: column wrap
+    margin-right: 16px
+    justify-content: center
+
+    // Wrap content horizontally in IE11
+    // Only use when the relative column sizes are predictable
+    // If only one flex-row child column has .wrapping-column, it will expand to fill any remaining row space. If more than one child column has .wrapping-column, the row is split according to flex-grow rules.
+    &.wrapping-column
+      flex: 1
+      flex-wrap: nowrap

--- a/app/assets/stylesheets/pano/global/_lists.sass
+++ b/app/assets/stylesheets/pano/global/_lists.sass
@@ -95,15 +95,3 @@ ul.accordian
 
 ol.plain, ul.plain
   +plain-list
-
-// FIXME:
-ul.inline
-  +plain-list
-  display: flex !important
-  flex-direction: row
-
-  li
-    display: flex
-    flex-flow: column wrap
-    margin-right: 16px
-    justify-content: center

--- a/app/assets/stylesheets/pano/global/index.sass
+++ b/app/assets/stylesheets/pano/global/index.sass
@@ -41,4 +41,5 @@
 @import '_transitions'
 @import '_date_picker'
 @import '_loading'
+@import '_flexbox'
 


### PR DESCRIPTION
Alternate fix for https://jira.surveymonkey.com/browse/SOLN-1990

- Adding new file _flexbox.sass (handles IE overflow by wrapping)
- Removing ul.inline styling