### PR TITLE
Fix SOLN-2045: Date filter dropdown too tall

### DIFF
--- a/app/assets/stylesheets/pano/global/_dropdowns.sass
+++ b/app/assets/stylesheets/pano/global/_dropdowns.sass
@@ -66,7 +66,7 @@
   ul.dropdown-menu
     position: absolute
     list-style: none
-    max-height: 500px
+    max-height: 350px
     min-width: 230px
     overflow-y: auto
     padding: 0


### PR DESCRIPTION
Fixes https://jira.surveymonkey.com/browse/SOLN-2045
- Change max-height of dropdowns from 500px to 350px

Fixed:
![screen shot 2018-11-14 at 3 49 29 pm](https://user-images.githubusercontent.com/8647584/48520355-2a8b3400-e825-11e8-9ff4-3c469079a72d.png)
