### PR TITLE
SOLN-2052: Add placeholder mm/dd/yyyy to date picker inputs

### DIFF
--- a/app/views/pano/components/_date_picker.haml
+++ b/app/views/pano/components/_date_picker.haml
@@ -5,10 +5,10 @@
         %h2 Select Time Frame
       .col-6.date-picker-range
         .form-group.inline-block
-          = f.formatted_date_field start_attr.to_sym, {data: {target: 'datepicker.start', action: 'active->datepicker#disableSubmit'}, format: 'MMM d, yyyy', placeholder: 'mm/dd/yyyy'}
+          = f.formatted_date_field start_attr.to_sym, {data: {target: 'datepicker.start', action: 'active->datepicker#disableSubmit'}, format: 'MMM d, yyyy', placeholder: 'MM/DD/YYYY'}
         %hr
         .form-group.inline-block
-          = f.formatted_date_field finish_attr.to_sym, {data: {target: 'datepicker.finish', action: 'active->datepicker#disableSubmit'}, format: 'MMM d, yyyy', placeholder: 'mm/dd/yyyy'}
+          = f.formatted_date_field finish_attr.to_sym, {data: {target: 'datepicker.finish', action: 'active->datepicker#disableSubmit'}, format: 'MMM d, yyyy', placeholder: 'MM/DD/YYYY'}
     .calendars.grid.g-8.m-stack.calendar-parent
     .date-picker-footer
       = link_to 'Cancel', js_void, class: 'btn btn-outline', data: {action: 'modals#close'}

--- a/app/views/pano/components/_date_picker.haml
+++ b/app/views/pano/components/_date_picker.haml
@@ -5,10 +5,10 @@
         %h2 Select Time Frame
       .col-6.date-picker-range
         .form-group.inline-block
-          = f.formatted_date_field start_attr.to_sym, {data: {target: 'datepicker.start', action: 'active->datepicker#disableSubmit'}, format: 'MMM d, yyyy'}
+          = f.formatted_date_field start_attr.to_sym, {data: {target: 'datepicker.start', action: 'active->datepicker#disableSubmit'}, format: 'MMM d, yyyy', placeholder: 'mm/dd/yyyy'}
         %hr
         .form-group.inline-block
-          = f.formatted_date_field finish_attr.to_sym, {data: {target: 'datepicker.finish', action: 'active->datepicker#disableSubmit'}, format: 'MMM d, yyyy'}
+          = f.formatted_date_field finish_attr.to_sym, {data: {target: 'datepicker.finish', action: 'active->datepicker#disableSubmit'}, format: 'MMM d, yyyy', placeholder: 'mm/dd/yyyy'}
     .calendars.grid.g-8.m-stack.calendar-parent
     .date-picker-footer
       = link_to 'Cancel', js_void, class: 'btn btn-outline', data: {action: 'modals#close'}


### PR DESCRIPTION
Fixes https://jira.surveymonkey.com/browse/SOLN-2052
Depends on: https://github.com/techvalidate/biome/pull/29

- Previously, if the date input was invalid, the format string was shown.
- Updated date picker to show 'mm/dd/yyyy' instead

After (user has not clicked on input):
![screen shot 2018-11-29 at 1 41 12 pm](https://user-images.githubusercontent.com/8647584/49253942-bd5acf80-f3dc-11e8-8afb-2ef71a2b4a18.png)

User has clicked on input (default uppercase for individual boxes of MM/DD/YYYY):
![screen shot 2018-11-29 at 1 41 02 pm](https://user-images.githubusercontent.com/8647584/49253962-cea3dc00-f3dc-11e8-9c07-6d118c7bfa6e.png)
