### PR TITLE
Fix SOLN-2062: IE11 calendar initial date population

### DIFF
--- a/app/models/pano/pano_form_builder.rb
+++ b/app/models/pano/pano_form_builder.rb
@@ -2,8 +2,7 @@ module Pano
   class PanoFormBuilder < ActionView::Helpers::FormBuilder
     def formatted_date_field(name, options = {})
       hidden_field = @template.hidden_field(@object_name, name, data: {target: 'hidden'})
-      # Format value to be parseable by new Date() in IE11. Use to_time not to_date, to prevent date misalignment
-      date = @template.tag('date-input', {name: "#{@object_name}[#{name}]", role: "textbox", value: @object.read_attribute(name) ? @object.read_attribute(name).to_time.iso8601 : (@object.send(name) ? @object.send(name).to_time.iso8601 : @object.send(name)), id: sanitize_to_id("#{@object_name}[#{name}]"), tabindex: 0, active: false}.update(options.stringify_keys))
+      date = @template.tag('date-input', {name: "#{@object_name}[#{name}]", role: "textbox", value: get_date_value(name), id: sanitize_to_id("#{@object_name}[#{name}]"), tabindex: 0, active: false}.update(options.stringify_keys))
       @template.safe_join([hidden_field, date])
     end
 
@@ -19,6 +18,16 @@ module Pano
 
     def sanitize_to_id(name)
       name.to_s.delete("]").tr("^-a-zA-Z0-9:.", "_")
+    end
+
+    def get_date_value(name)
+      # get name attribute or invode name method for date value
+      value = @object.read_attribute(name) || @object.send(name)
+      if !value.nil?
+        # Format date so IE11 new Date() can parse it. Use to_time not to_date, to prevent date misalignment
+        value = value.to_time.iso8601
+      end
+      value
     end
   end
 end


### PR DESCRIPTION
Fixes: https://jira.surveymonkey.com/browse/SOLN-2062
Dependents: https://github.com/techvalidate/engage/pull/2025

- update formatted_date_field() to use iso8601 format so that it can be parsed by IE11 new Date()
- Previous format meant the initial dates would be considered invalid in IE11

After:
<img width="726" alt="screen shot 2018-11-30 at 5 24 25 pm" src="https://user-images.githubusercontent.com/8647584/49322477-d2129280-f4c4-11e8-8d28-108e8196834d.png">
