### PR TITLE
SOLN 2042: Expect date value to contains timezone info

### DIFF
--- a/app/models/pano/pano_form_builder.rb
+++ b/app/models/pano/pano_form_builder.rb
@@ -21,11 +21,15 @@ module Pano
     end
 
     def get_date_value(name)
-      # get name attribute or invode name method for date value
+      # get name attribute or invoke name method for datetime value
+      # value should be in the local timezone with the timezone specified
       value = @object.read_attribute(name) || @object.send(name)
+
       if !value.nil?
-        # Format date so IE11 new Date() can parse it. Use to_time not to_date, to prevent date misalignment
-        value = value.to_time.iso8601
+        # NOTE: If value does not have timezone info, value.iso8601 will not contain timezone info either.
+        # This can cause problems when the client assumes value is in UTC (although it may already be in the local timezone), and then converts it from UTC to the local timezone
+        # Format to iso8601 so IE11 new Date() can parse it
+        value = value.iso8601
       end
       value
     end


### PR DESCRIPTION
For: https://jira.surveymonkey.com/browse/SOLN-2042

- Previously: date **value** was obtained from **survey.launch_on_datetime or survey.close_on_datetime.**
  - It only contained the date info with no associated timezone.
  - This caused problems when the client assumes value is in UTC (although it may already be in the local timezone), and then converts it from UTC to the local timezone
- Update: Expect **value** to be obtained from **survey.launch_on_datetime or survey.close_on_datetime.**
  - It will then have timezone information associated with it, which can be correctly passed to the client.

For example:
**Before: Using launch_on**
Database launch_at: 2019-02-05 18:00:00 (in UTC)
get_date_value(**:launch_on**):
  - survey.launch_at = Tue, 05 Feb 2019 10:00:00 PST -08:00 (ActiveSupport::TimeWithZone)
  - survey.launch_at.iso8601 = "2019-02-05T10:00:00-08:00" (String)
  - value = survey.launch_on = survey.launch_at&.to_date = Tue, 05 Feb 2019 (Date,  in the local timezone)
  - value.to_time = 2019-02-05 00:00:00 -0800 (Time)
  - value.to_time.iso8601 = "2019-02-05T00:00:00-08:00" (String)
  - value.to_date = value =Tue, 05 Feb 2019 (Date,  in the local timezone)
  - value.to_date.iso8601 is "2019-02-05" (String)

**After: Using launch_on_datetime**
get_date_value(**:launch_on_datetime**):
  - value = survey.launch_on_datetime = survey.launch_at&.to_time = 2019-02-05 10:00:00 -0800 (Time)
  - value.iso8601 = "2019-02-05T10:00:00-08:00" (String)

