### PR TITLE
Reverting datepicker to previous version

### DIFF
--- a/app/views/pano/components/_date_picker.haml
+++ b/app/views/pano/components/_date_picker.haml
@@ -5,16 +5,11 @@
         %h2 Select Time Frame
       .col-6.date-picker-range
         .form-group.inline-block
-          = f.formatted_date_field start_attr.to_sym, {data: {target: 'datepicker.start', action: 'change->datepicker#setStartCal active->datepicker#disableSubmit'}, format: 'MMM d, yyyy'}
+          = f.formatted_date_field start_attr.to_sym, {data: {target: 'datepicker.start', action: 'active->datepicker#disableSubmit'}, format: 'MMM d, yyyy', placeholder: 'MM/DD/YYYY'}
         %hr
         .form-group.inline-block
-          = f.formatted_date_field finish_attr.to_sym, {data: {target: 'datepicker.finish', action: 'change->datepicker#setFinishCal active->datepicker#disableSubmit'}, format: 'MMM d, yyyy'}
-    .calendars.grid.g-8.m-stack
-      .col-6
-        .start{data: {target: 'datepicker.startCalendar'}}
-      .calendars-seperator
-      .col-6
-        .finish{data: {target: 'datepicker.finishCalendar'}}
+          = f.formatted_date_field finish_attr.to_sym, {data: {target: 'datepicker.finish', action: 'active->datepicker#disableSubmit'}, format: 'MMM d, yyyy', placeholder: 'MM/DD/YYYY'}
+    .calendars.grid.g-8.m-stack.calendar-parent
     .date-picker-footer
       = link_to 'Cancel', js_void, class: 'btn btn-outline', data: {action: 'modals#close'}
       = link_to submit_label, js_void, class: 'btn btn-primary', data: {target: 'datepicker.submit', action: 'datepicker#apply'}


### PR DESCRIPTION
- Prevent missing .calendar-parent error and remove use of setStartCal() which no longer exists.